### PR TITLE
User validations

### DIFF
--- a/app/models/planet.rb
+++ b/app/models/planet.rb
@@ -5,5 +5,6 @@ class Planet < ApplicationRecord
   validates :capacity, presence: true, numericality: { greater_than: 0 }
   belongs_to :user
   belongs_to :environment
+  has_many :bookings
   has_many_attached :photos
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,16 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-
+  # user must have a unique email (validated by devise)
+  # user must have a first name and last name
+  validates :email, presence: :true, uniqueness: :true
+  validates :first_name, presence: :true
+  validates :last_name, presence: :true
+  has_many :planets
+  has_many :bookings
+  # this is so that a traveller will have planets but only through bookings
+  has_many :destination_planets, through: :bookings, source: :planet
+  # while an overlord will have bookings but only through planets
+  has_many :incoming_bookings, through: :planets, source: :bookings
+  # as opposed to a traveller "owning" the planet or an overlord *making* a booking
 end

--- a/db/migrate/20200225155608_remove_column.rb
+++ b/db/migrate/20200225155608_remove_column.rb
@@ -1,0 +1,5 @@
+class RemoveColumnFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :role, :string
+  end
+end

--- a/db/migrate/20200225155608_remove_column.rb
+++ b/db/migrate/20200225155608_remove_column.rb
@@ -1,5 +1,0 @@
-class RemoveColumnFromUsers < ActiveRecord::Migration[5.2]
-  def change
-    remove_column :users, :role, :string
-  end
-end

--- a/db/migrate/20200225155608_update_columns_in_users.rb
+++ b/db/migrate/20200225155608_update_columns_in_users.rb
@@ -1,6 +1,7 @@
 class UpdateColumnsInUsers < ActiveRecord::Migration[5.2]
   def change
     remove_column :users, :role, :string
-
+    add_column :users, :traveller, :boolean, default: true
+    add_column :users, :overlord, :boolean, default: false
   end
 end

--- a/db/migrate/20200225155608_update_columns_in_users.rb
+++ b/db/migrate/20200225155608_update_columns_in_users.rb
@@ -1,0 +1,6 @@
+class UpdateColumnsInUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :role, :string
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_24_224550) do
+ActiveRecord::Schema.define(version: 2020_02_25_155608) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,7 +84,8 @@ ActiveRecord::Schema.define(version: 2020_02_24_224550) do
     t.string "first_name"
     t.string "last_name"
     t.string "nickname"
-    t.string "role"
+    t.boolean "traveller", default: true
+    t.boolean "overlord", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
added 2 new columns (removed 'role') and added traveller and overlord as a boolean, then added associations in bookings and planets so that a traveller can "have" planets through bookings, named "destination_planets" and an overlord can have planets that they own, but can only "have" bookings through planets that they own.